### PR TITLE
Make it work similarly to the file-loader

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,18 @@
 /*
-	MIT License http://www.opensource.org/licenses/mit-license.php
-	Author Tobias Koppers @sokra
+    MIT License http://www.opensource.org/licenses/mit-license.php
+    Author Tobias Koppers @sokra
+    Edited Guilherme Bernal @lbguilherme
 */
-module.exports = function() {
-	return "try {process.dlopen(" + JSON.stringify(this.resourcePath) + ", module.exports); } catch(e) {" +
-		"throw new Error('Cannot open ' + " + JSON.stringify(this.resourcePath) + " + ': ' + e);}";
+module.exports = function(content) {
+    this.cacheable && this.cacheable();
+    if (!this.emitFile) throw new Error("emitFile is required from module system");
+    var query = loaderUtils.parseQuery(this.query);
+    var url = loaderUtils.interpolateName(this, query.name || "[hash].[ext]", {
+        context: query.context || this.options.context,
+        content: content,
+        regExp: query.regExp
+    });
+    this.emitFile(url, content);
+    return "try { global.process.dlopen(module, __webpack_public_path__ + " + JSON.stringify(url) + "); } catch(e) { " +
+        "throw new Error('Cannot load native module ' + " + JSON.stringify(url) + " + ': ' + e); }";
 }


### PR DESCRIPTION
Emit the .node file locally and refer to it instead of using a absolute path.
